### PR TITLE
Remove asset from Sticker

### DIFF
--- a/data/src/main/scala/ackcord/data/raw/rawData.scala
+++ b/data/src/main/scala/ackcord/data/raw/rawData.scala
@@ -1163,8 +1163,6 @@ case class RawEmoji(
   *   Description of the sticker.
   * @param tags
   *   A comma-separated list of tags for the sticker.
-  * @param asset
-  *   Sticker asset hash.
   * @param `type`
   *   Type of the sticker.
   * @param formatType
@@ -1184,7 +1182,6 @@ case class RawSticker(
     name: String,
     description: Option[String],
     tags: Option[String],
-    asset: String,
     `type`: StickerType,
     formatType: FormatType,
     available: Option[Boolean],
@@ -1199,7 +1196,6 @@ case class RawSticker(
     name,
     description,
     tags,
-    asset,
     `type`,
     formatType,
     available,

--- a/data/src/main/scala/ackcord/data/sticker.scala
+++ b/data/src/main/scala/ackcord/data/sticker.scala
@@ -64,8 +64,6 @@ object StickerType extends IntEnum[StickerType] with IntCirceEnumWithUnknown[Sti
   *   Description of the sticker.
   * @param tags
   *   A comma-separated list of tags for the sticker.
-  * @param asset
-  *   Sticker asset hash.
   * @param tpe`
   *   Type of the sticker.
   * @param formatType
@@ -85,7 +83,6 @@ case class Sticker(
     name: String,
     description: Option[String],
     tags: Option[String],
-    asset: String,
     tpe: StickerType,
     formatType: FormatType,
     available: Option[Boolean],


### PR DESCRIPTION
From dev docs:
`Deprecated previously the sticker asset hash, now an empty string`

I'm also somehow getting `DecodingFailure`'s from it: 
`Attempt to decode value on failed cursor: DownField(asset),DownArray,DownField(stickers),DownField(d)`